### PR TITLE
Add damage frames to Characters without respire

### DIFF
--- a/Characters/Bella/Bella.tres
+++ b/Characters/Bella/Bella.tres
@@ -3,10 +3,10 @@
 [ext_resource type="Resource" uid="uid://cf8edtn2vh585" path="res://Characters/Template_Attribute_Set.tres" id="1_a2ycu"]
 [ext_resource type="SpriteFrames" uid="uid://dnrmm221vgxdg" path="res://Characters/Bella/BellaAnimations.tres" id="1_i5e1t"]
 [ext_resource type="Script" path="res://Scripts/Characters/CharacterResource.gd" id="1_pguks"]
-[ext_resource type="Texture2D" uid="uid://cukgdoaxwsd2w" path="res://Characters/Bella/Textures/bellaicon.png" id="2_nncx1"]
+[ext_resource type="Texture2D" uid="uid://cukgdoaxwsd2w" path="res://Characters/Bella/Textures/bellaicon.png" id="3_u55lk"]
 
 [resource]
 script = ExtResource("1_pguks")
 character_animations = ExtResource("1_i5e1t")
-icon = ExtResource("2_nncx1")
+icon = ExtResource("3_u55lk")
 attribute_set = ExtResource("1_a2ycu")

--- a/Scripts/Characters/HitBox.gd
+++ b/Scripts/Characters/HitBox.gd
@@ -33,8 +33,10 @@ func _physics_process(_delta):
 			# increase damage taken by 1% for each overlapping area
 			damage_multiplier *= 1.01
 
+
 	if overlapping_areas.size() > 0 and invisiblitytime >= invisiblityframetime:
 		Stat.Modify(get_parent(),"health", 1*damage_multiplier,"-")
+		Stat.Set(get_parent(), "is_damaged", 1)
 		#print("damage taken: ",1*damage_multiplier)
 		invisiblitytime = 0
 	#print(Stat.get_stat(area.get_parent(),"health",{"shape_id" : shape}))

--- a/Scripts/Characters/PlayerSprite.gd
+++ b/Scripts/Characters/PlayerSprite.gd
@@ -9,6 +9,8 @@ extends Node2D
 
 var lastfliptime = 0
 
+var damage_frames = 0
+
 func _ready():
 	#fallback if not assigned
 	if animated_sprite == null:
@@ -32,4 +34,14 @@ func _physics_process(_delta):
 	elif character_sprite.velocity.x < 0 and lastfliptime + fliptimelimit < Time.get_ticks_msec():
 		animated_sprite.flip_h = true
 		lastfliptime = Time.get_ticks_msec()
-
+		
+	if Stat.Get(get_parent(), "is_damaged") == 1 and damage_frames == 0:
+		Stat.Set(get_parent(), "is_damaged", 0)
+		damage_frames = 20
+	
+	if damage_frames > 0:
+		if damage_frames == 20:
+			animated_sprite.modulate = Color(1, 0, 0, .8)
+		if damage_frames == 1:
+			animated_sprite.modulate = Color(1, 1, 1)
+		damage_frames -= 1

--- a/Scripts/Characters/PlayerSprite.gd
+++ b/Scripts/Characters/PlayerSprite.gd
@@ -41,7 +41,7 @@ func _physics_process(_delta):
 	
 	if damage_frames > 0:
 		if damage_frames == 20:
-			animated_sprite.modulate = Color(1, 0, 0, .8)
+			animated_sprite.modulate = Color(1, .4, .4)
 		if damage_frames == 1:
 			animated_sprite.modulate = Color(1, 1, 1)
 		damage_frames -= 1


### PR DESCRIPTION
This is a small feature impl with the intention of keeping the original character frames playing while displaying damaging feedback. This is done via the modulate property. This way there is no requirement for separate damage frames (though might worth looking into having modifiable frame, with like a >_< face when damaged)